### PR TITLE
Support comment preview and some fixes

### DIFF
--- a/src/main/resources/embedding/assets/entry.js
+++ b/src/main/resources/embedding/assets/entry.js
@@ -89,7 +89,18 @@ $(function(){
                 }catch(e){}
             }
         }
-        prettyPrint();
     }
+
+    // Initial processing
     convertLinks();
+    prettyPrint();
+
+    setTimeout(function(){ // Delayed execution
+        // Create a hook for prettyPrint function to support preview
+        const original = prettyPrint;
+        prettyPrint = function(){
+            convertLinks();
+            return original.apply(this, arguments);
+        }
+    });
 })

--- a/src/main/resources/embedding/assets/entry.js
+++ b/src/main/resources/embedding/assets/entry.js
@@ -57,6 +57,10 @@ $(function(){
         return xmlHttp.responseText;
     }
 
+    function escapeHtml(text) {
+        return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+    }
+
     function convertLinks(){
         const elements = $('.markdown-body p');
         let element;
@@ -80,9 +84,12 @@ $(function(){
                 }
                 let commitUrl = getCommitUrl(url, filepath);
                 try{
+                    filepath = decodeURIComponent(filepath);
+                    filepath = escapeHtml(filepath);
                     let content = getContent(url);
                     let linesAll = content.split(/\n|\r\n?/);
                     let lines = linesAll.slice(startLine-1, endLine).join("\n");
+                    lines = escapeHtml(lines);
                     let snippetElement = generateSnippetElement(repo, filepath, commit, startLine, endLine, lines, url, commitUrl);
                     element.insertAdjacentHTML('afterend', snippetElement);
                     element.remove();

--- a/src/main/resources/embedding/assets/entry.js
+++ b/src/main/resources/embedding/assets/entry.js
@@ -25,7 +25,7 @@ $(function(){
             "<span style='font-size:11px;'><a href=" + commitUrl + ">" + commit + "</a></span>",
             "</div>",
             "<div class='panel-body' style='padding:0; background-color:white;'>",
-            "<pre class='embedded-snippet prettyprint linenums:" + lineStartNum + "' style='padding-left:15px; margin-bottom:0;'>",
+            "<pre class='embedded-snippet prettyprint linenums:" + lineStartNum + "' data-filename='" + filename + "' style='padding-left:15px; margin-bottom:0;'>",
             content,
             "</pre>",
             "</div>",

--- a/src/main/resources/embedding/assets/entry.js
+++ b/src/main/resources/embedding/assets/entry.js
@@ -81,7 +81,7 @@ $(function(){
                 let commitUrl = getCommitUrl(url, filepath);
                 try{
                     let content = getContent(url);
-                    let linesAll = content.split("\n");
+                    let linesAll = content.split(/\n|\r\n?/);
                     let lines = linesAll.slice(startLine-1, endLine).join("\n");
                     let snippetElement = generateSnippetElement(repo, filepath, commit, startLine, endLine, lines, url, commitUrl);
                     element.insertAdjacentHTML('afterend', snippetElement);


### PR DESCRIPTION
Thank you for this useful plugin.
I have made some fixes.

- **Support comment preview**
  Resolves #4.
  Currently, this preview support stops working after editing comments.
  I opened PR gitbucket/gitbucket#2922 to fix this.
- **Support CR or CRLF line endings**
- **Add url decoding and html escaping**
- **Add `data-filename` class to snippets**
  This is an addition for my [code-highlighter-plugin](https://github.com/kaz-on/gitbucket-code-highlighter-plugin).
  I would be happy if you could add it to your plugin :)
